### PR TITLE
Hot reload and pre-built II wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ src/declarations
 # frontend code
 node_modules/
 dist/
+
+
+internet_identity.did
+internet_identity.wasm

--- a/dfx.json
+++ b/dfx.json
@@ -16,6 +16,16 @@
         "dist/gather_assets/"
       ],
       "type": "assets"
+    },
+    "internet_identity": {
+      "__00": "from https://github.com/dfinity/internet-identity/blob/main/demos/using-dev-build/README.md",
+      "__0": "The development build of Internet Identity. For more information, see https://github.com/dfinity/internet-identity#build-features-and-flavors",
+      "type": "custom",
+      "candid": "internet_identity.did",
+      "wasm": "internet_identity.wasm",
+      "__1": "There is no standard way to pull remote canisters, so instead we have a dummy build script that",
+      "__2": "simply downloads the Internet Identity canister. See also: https://github.com/dfinity/sdk/issues/2085",
+      "build": "./scripts/download-did-and-wasm"
     }
   },
   "defaults": {
@@ -24,7 +34,7 @@
       "packtool": ""
     }
   },
-  "dfx": "0.9.3",
+  "dfx": "0.11.2",
   "networks": {
     "ic": {
       "providers": [
@@ -33,7 +43,7 @@
       "type": "persistent"
     },
     "local": {
-      "bind": "localhost:8000",
+      "bind": "127.0.0.1:8000",
       "type": "ephemeral"
     }
   },

--- a/scripts/download-did-and-wasm
+++ b/scripts/download-did-and-wasm
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# This script copied from https://github.com/dfinity/internet-identity/blob/main/demos/using-dev-build/scripts/download-did-and-wasm
+set -euo pipefail
+
+# Download the Internet Identity canister's development wasm as well as its candid interface file. See dfx.json for details.
+curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm -o internet_identity.wasm
+curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity.did

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,7 +109,7 @@ module.exports = {
     new webpack.EnvironmentPlugin({
       NODE_ENV: "development",
       II_URL: isDevelopment
-        ? "http://rrkah-fqaaa-aaaaa-aaaaq-cai.localhost:8000#authorize"
+        ? "http://r7inp-6aaaa-aaaaa-aaabq-cai.localhost:8000#authorize"
         : "https://identity.ic0.app/#authorize",
       ...canisterEnvVariables,
     }),
@@ -122,7 +122,7 @@ module.exports = {
   devServer: {
     proxy: {
       "/api": {
-        target: "http://localhost:8000",
+        target: "http://127.0.0.1:8000",
         changeOrigin: true,
         pathRewrite: {
           "^/api": "/api",
@@ -130,7 +130,26 @@ module.exports = {
       },
     },
     hot: true,
-    watchFiles: [path.resolve(__dirname, "src", frontendDirectory)],
     liveReload: true,
+    port: 3000,
+    allowedHosts: [
+      '.localhost',
+      '127.0.0.1'
+    ],
+    historyApiFallback: true,
+    static: {
+      directory: path.resolve(__dirname, "static"),
+      staticOptions: {},
+      // Don't be confused with `devMiddleware.publicPath`, it is `publicPath` for static directory
+      // Can be:
+      // publicPath: ['/static-public-path-one/', '/static-public-path-two/'],
+      publicPath: "./src/frontend",
+      // Can be:
+      // serveIndex: {} (options for the `serveIndex` option you can find https://github.com/expressjs/serve-index)
+      serveIndex: true,
+      // Can be:
+      // watch: {} (options for the `watch` option you can find https://github.com/paulmillr/chokidar)
+      watch: true,
+    },
   },
 };


### PR DESCRIPTION
Uses the pre-built dev Internet Identity wasm instead of requiring developer to compile themselves
Enables hot reload by using "npm start" to launch